### PR TITLE
upgrade node runtime used by lambda

### DIFF
--- a/ror/vpc/lambda.tf
+++ b/ror/vpc/lambda.tf
@@ -20,7 +20,7 @@ resource "aws_lambda_function" "index-page-community" {
   function_name = "index-page-community"
   role = aws_iam_role.iam_for_lambda.arn
   handler = "index-page-runner.handler"
-  runtime = "nodejs14.x"
+  runtime = "nodejs12.x"
   source_code_hash = sha256(filebase64("index-page-runner.js.zip"))
   publish = true
 }
@@ -32,7 +32,7 @@ resource "aws_lambda_function" "redirect-community" {
   function_name = "redirect-community"
   role = aws_iam_role.iam_for_lambda.arn
   handler = "redirect-runner.handler"
-  runtime = "nodejs14.x"
+  runtime = "nodejs12.x"
   source_code_hash = sha256(filebase64("redirect-runner.js.zip"))
   publish = true
 }

--- a/ror/vpc/lambda.tf
+++ b/ror/vpc/lambda.tf
@@ -8,31 +8,31 @@
 
 //   environment {
 //     variables = {
-      
+
 //     }
 //   }
 // }
 
 resource "aws_lambda_function" "index-page-community" {
   provider = aws.use1
-  
+
   filename = "index-page-runner.js.zip"
   function_name = "index-page-community"
   role = aws_iam_role.iam_for_lambda.arn
   handler = "index-page-runner.handler"
-  runtime = "nodejs10.x"
+  runtime = "nodejs14.x"
   source_code_hash = sha256(filebase64("index-page-runner.js.zip"))
   publish = true
 }
 
 resource "aws_lambda_function" "redirect-community" {
   provider = aws.use1
-  
+
   filename = "redirect-runner.js.zip"
   function_name = "redirect-community"
   role = aws_iam_role.iam_for_lambda.arn
   handler = "redirect-runner.handler"
-  runtime = "nodejs10.x"
+  runtime = "nodejs14.x"
   source_code_hash = sha256(filebase64("redirect-runner.js.zip"))
   publish = true
 }


### PR DESCRIPTION
upgrade node runtime used by lambda as 10x is no longer supported and causes TF run to fail