### PR TITLE
update reconciler log group to match name in container config

### DIFF
--- a/ror/services/reconcile/main.tf
+++ b/ror/services/reconcile/main.tf
@@ -52,7 +52,7 @@ resource "aws_lb_listener_rule" "reconcile-community" {
 }
 
 resource "aws_cloudwatch_log_group" "reconcile" {
-  name = "/ecs/reconcile-community"
+  name = "/ecs/reconcile"
 }
 
 resource "aws_ecs_task_definition" "reconcile" {


### PR DESCRIPTION
Log group "reconcile-community" created in AWS does not match name of log group in container vars "reconcile". This is causing problems starting the container.