### PR TITLE
Map query string parameters to development API Gateway integration requests

### DIFF
--- a/ror/services/api/api_gateway_dev_full.tf
+++ b/ror/services/api/api_gateway_dev_full.tf
@@ -707,6 +707,18 @@ resource "aws_api_gateway_integration" "v2_proxy_dev" {
     "integration.request.path.proxy"                     = "method.request.path.proxy"
     "integration.request.header.Host"                    = "stageVariables.api_host"
     "integration.request.header.X-ROR-API-Gateway-Token" = "'${var.api_gateway_token}'"
+    "integration.request.querystring.query"              = "method.request.querystring.query"
+    "integration.request.querystring.page"               = "method.request.querystring.page"
+    "integration.request.querystring.affiliation"        = "method.request.querystring.affiliation"
+    "integration.request.querystring.filter"             = "method.request.querystring.filter"
+    "integration.request.querystring.format"             = "method.request.querystring.format"
+    "integration.request.querystring.all_status"         = "method.request.querystring.all_status"
+    "integration.request.querystring.query.advanced"     = "method.request.querystring.query.advanced"
+    "integration.request.querystring.query.name"         = "method.request.querystring.query.name"
+    "integration.request.querystring.query.names"        = "method.request.querystring.query.names"
+    "integration.request.querystring.page_size"          = "method.request.querystring.page_size"
+    "integration.request.querystring.single_search"      = "method.request.querystring.single_search"
+    "integration.request.querystring.multisearch"        = "method.request.querystring.multisearch"
   }
 
   cache_key_parameters = [
@@ -741,6 +753,18 @@ resource "aws_api_gateway_integration" "root_proxy_dev" {
     "integration.request.path.proxy"                     = "method.request.path.proxy"
     "integration.request.header.Host"                    = "stageVariables.api_host"
     "integration.request.header.X-ROR-API-Gateway-Token" = "'${var.api_gateway_token}'"
+    "integration.request.querystring.query"              = "method.request.querystring.query"
+    "integration.request.querystring.page"               = "method.request.querystring.page"
+    "integration.request.querystring.affiliation"        = "method.request.querystring.affiliation"
+    "integration.request.querystring.filter"             = "method.request.querystring.filter"
+    "integration.request.querystring.format"             = "method.request.querystring.format"
+    "integration.request.querystring.all_status"         = "method.request.querystring.all_status"
+    "integration.request.querystring.query.advanced"     = "method.request.querystring.query.advanced"
+    "integration.request.querystring.query.name"         = "method.request.querystring.query.name"
+    "integration.request.querystring.query.names"        = "method.request.querystring.query.names"
+    "integration.request.querystring.page_size"          = "method.request.querystring.page_size"
+    "integration.request.querystring.single_search"      = "method.request.querystring.single_search"
+    "integration.request.querystring.multisearch"        = "method.request.querystring.multisearch"
   }
 
   cache_key_parameters = [


### PR DESCRIPTION
## Purpose

The purpose of this PR is to ensure that relevant query string parameters are correctly passed from the AWS API Gateway to the backend integration in the development environment. This ensures that search, filtering, and pagination functionality works as expected when accessed through the gateway.

## Approach

I have updated the Terraform configuration for the development API Gateway to explicitly map a comprehensive list of supported query string parameters to the integration requests.

### Key Modifications

- Updated `aws_api_gateway_integration.v2_proxy_dev` to include 12 additional query string mappings.
- Updated `aws_api_gateway_integration.root_proxy_dev` to include the same 12 query string mappings.
- The following parameters are now mapped:
    - `query`, `query.advanced`, `query.name`, `query.names`
    - `page`, `page_size`
    - `affiliation`, `filter`, `format`, `all_status`
    - `single_search`, `multisearch`

### Important Technical Details

The mappings use the standard AWS API Gateway integration request format: `"integration.request.querystring.PARAMETER" = "method.request.querystring.PARAMETER"`. This ensures that the backend service receives the parameters exactly as they were sent by the client.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.