### PR TITLE
feat: Enforce HTTPS for dev Elasticsearch and API services

### DIFF
--- a/ror/data-storage/elasticsearch/dev.tf
+++ b/ror/data-storage/elasticsearch/dev.tf
@@ -27,6 +27,11 @@ resource "aws_elasticsearch_domain" "elasticsearch-v7-dev" {
     subnet_ids = var.private_subnet_ids
   }
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
   log_publishing_options {
     cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.es-v7-dev.arn}"
     enabled = true

--- a/ror/services/api/var.tf
+++ b/ror/services/api/var.tf
@@ -24,7 +24,7 @@ variable "elastic7_host_dev" {
   default = "elasticsearch-v7.dev.ror.org"
 }
 variable "elastic7_port_dev" {
-  default = "80"
+  default = "443"
 }
 variable "elastic7_host_staging" {
   default = "elasticsearch-v7.staging.ror.org"


### PR DESCRIPTION
## Purpose

This PR updates the configuration for the development Elasticsearch domain and API services to enforce HTTPS.

## Approach

The changes involve modifying the Terraform configuration for the Elasticsearch domain and the API service variables.

### Key Modifications

*   **Elasticsearch Domain Configuration:**
    *   Added `domain_endpoint_options` block to `aws_elasticsearch_domain.elasticsearch-v7-dev`.
    *   Set `enforce_https` to `true`.
    *   Set `tls_security_policy` to `Policy-Min-TLS-1-2-2019-07`.
*   **API Service Variables:**
    *   Updated the default value for `elastic7_port_dev` from `"80"` to `"443"` to reflect the use of HTTPS.

### Important Technical Details

*   Enforcing HTTPS on the Elasticsearch domain ensures secure communication.
*   Setting the `tls_security_policy` to `Policy-Min-TLS-1-2-2019-07` mandates a minimum TLS version of 1.2, enhancing security.
*   The corresponding change in the API service variable for the port ensures that the API connects to Elasticsearch using the correct port for HTTPS.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.