### PR TITLE
feat: Disable HTTPS enforcement and set TLS policy for staging Elasticsearch

### DIFF
--- a/ror/data-storage/elasticsearch/staging.tf
+++ b/ror/data-storage/elasticsearch/staging.tf
@@ -27,6 +27,11 @@ resource "aws_elasticsearch_domain" "elasticsearch-v7-staging" {
     subnet_ids = var.private_subnet_ids
   }
 
+  domain_endpoint_options {
+    enforce_https       = false
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
   log_publishing_options {
     cloudwatch_log_group_arn = "${aws_cloudwatch_log_group.es-v7-staging.arn}"
     enabled = true


### PR DESCRIPTION
## Purpose

This PR modifies the Elasticsearch domain configuration in staging to disable HTTPS enforcement and set a specific TLS security policy.

## Approach

The existing Elasticsearch domain resource in `ror/data-storage/elasticsearch/staging.tf` is updated to include a `domain_endpoint_options` block.

### Key Modifications

- Added `domain_endpoint_options` block to the `aws_elasticsearch_domain` resource.
- Set `enforce_https` to `false`.
- Set `tls_security_policy` to `Policy-Min-TLS-1-2-2019-07`.

### Important Technical Details

Disabling HTTPS enforcement means that the Elasticsearch domain will be accessible over HTTP. The `Policy-Min-TLS-1-2-2019-07` setting specifies the minimum TLS version allowed for connections, ensuring a certain level of security even with HTTPS enforcement disabled.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.