### PR TITLE
fix: Remove create_before_destroy from api_gateway_dev_full to resolve cyclic dependency

### DIFF
--- a/ror/services/api/api_gateway_dev_full.tf
+++ b/ror/services/api/api_gateway_dev_full.tf
@@ -1333,9 +1333,6 @@ resource "aws_api_gateway_deployment" "api_gateway_dev_full" {
     aws_api_gateway_integration_response.v2_organizations_options_dev
   ]
 
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 # =============================================================================


### PR DESCRIPTION
## Purpose

This PR addresses a cyclic dependency issue in the `api_gateway_dev_full.tf` file.

## Approach

The cyclic dependency was caused by the `lifecycle.create_before_destroy` setting in the `aws_api_gateway_deployment` resource. This setting was removed to resolve the dependency.

### Key Modifications

*   Removed `lifecycle { create_before_destroy = true }` block from `aws_api_gateway_deployment.api_gateway_dev_full`.

### Important Technical Details

The `create_before_destroy` lifecycle rule, when applied to resources like API Gateway deployments that have dependencies on other resources (like integrations and methods), can inadvertently create a situation where a new deployment is attempted before the previous one is fully destroyed, leading to a cyclic dependency. Removing this rule allows Terraform to manage the destruction and creation order more effectively in this scenario.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.