### PR TITLE
Refactor: Reduce API Gateway deployment dependencies

### DIFF
--- a/ror/services/api/api_gateway_dev_full.tf
+++ b/ror/services/api/api_gateway_dev_full.tf
@@ -1312,26 +1312,12 @@ resource "aws_api_gateway_deployment" "api_gateway_dev_full" {
     aws_api_gateway_integration.organizations_orgid_options_dev,
     aws_api_gateway_integration.organizations_options_dev,
     aws_api_gateway_integration.v2_organizations_orgid_options_dev,
-    aws_api_gateway_integration.v2_organizations_options_dev,
-    aws_api_gateway_integration_response.v1_proxy_410_dev,
-    aws_api_gateway_integration_response.v1_heartbeat_get_410_dev,
-    aws_api_gateway_integration_response.v2_heartbeat_get_dev,
-    aws_api_gateway_integration_response.heartbeat_get_dev,
-    aws_api_gateway_integration_response.generateid_get_dev,
-    aws_api_gateway_integration_response.organizations_orgid_get_dev,
-    aws_api_gateway_integration_response.organizations_any_dev,
-    aws_api_gateway_integration_response.v2_organizations_orgid_get_dev,
-    aws_api_gateway_integration_response.v2_organizations_any_dev,
-    aws_api_gateway_integration_response.v1_proxy_options_dev,
-    aws_api_gateway_integration_response.v1_heartbeat_options_dev,
-    aws_api_gateway_integration_response.v2_heartbeat_options_dev,
-    aws_api_gateway_integration_response.heartbeat_options_dev,
-    aws_api_gateway_integration_response.generateid_options_dev,
-    aws_api_gateway_integration_response.organizations_orgid_options_dev,
-    aws_api_gateway_integration_response.organizations_options_dev,
-    aws_api_gateway_integration_response.v2_organizations_orgid_options_dev,
-    aws_api_gateway_integration_response.v2_organizations_options_dev
+    aws_api_gateway_integration.v2_organizations_options_dev
   ]
+
+  lifecycle {
+    create_before_destroy = true
+  }
 
 }
 


### PR DESCRIPTION
## Purpose

This PR aims to reduce the number of direct dependencies within the API Gateway deployment by consolidating integration resources.

## Approach

By removing redundant references to `aws_api_gateway_integration_response` resources that are implicitly handled by other integrations, we simplify the deployment configuration. Additionally, a `lifecycle` block with `create_before_destroy = true` is added to ensure a smoother transition during updates by creating the new deployment before destroying the old one.

### Key Modifications

*   Removed numerous explicit references to `aws_api_gateway_integration_response` resources within the `aws_api_gateway_deployment.api_gateway_dev_full` resource.
*   Added a `lifecycle` block with `create_before_destroy = true` to the `aws_api_gateway_deployment` resource.

### Important Technical Details

The removal of explicit `aws_api_gateway_integration_response` resources is safe because some of these responses are implicitly managed by their corresponding `aws_api_gateway_integration` resources. This change leads to fewer direct `depends_on` attributes in the deployment, making the configuration cleaner and potentially easier to manage. The `create_before_destroy` lifecycle rule is a standard practice for minimizing downtime during deployments.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.