### PR TITLE
feat: Add create_before_destroy to aws_api_gateway_deployment

### DIFF
--- a/ror/services/api/api_gateway_staging_full.tf
+++ b/ror/services/api/api_gateway_staging_full.tf
@@ -1603,6 +1603,10 @@ resource "aws_api_gateway_deployment" "api_gateway_staging_full" {
     aws_api_gateway_integration_response.v2_organizations_options_staging
   ]
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
 }
 
 # =============================================================================


### PR DESCRIPTION
## Purpose

This PR introduces a change to the `aws_api_gateway_deployment` resource in the `api_gateway_staging_full.tf` file.

## Approach

The primary modification is the addition of a `lifecycle` block with `create_before_destroy = true` to the `aws_api_gateway_deployment` resource.

### Key Modifications

*   Added `lifecycle { create_before_destroy = true }` to `aws_api_gateway_deployment.api_gateway_staging_full`.

### Important Technical Details

The `create_before_destroy = true` setting ensures that a new API Gateway deployment is created before the old one is destroyed. This is crucial for minimizing downtime during deployments, as it allows traffic to be seamlessly switched to the new deployment once it's ready.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.