### PR TITLE
feat: Add support for ror.org/ prefix in orgIds

### DIFF
--- a/ror/services/api/api_gateway_dev_full.tf
+++ b/ror/services/api/api_gateway_dev_full.tf
@@ -76,11 +76,11 @@ resource "aws_api_gateway_resource" "v2_organizations_dev" {
   path_part   = "organizations"
 }
 
-# v2/organizations/{orgid} resource
+# v2/organizations/{orgid+} resource
 resource "aws_api_gateway_resource" "v2_organizations_orgid_dev" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_dev.id
   parent_id   = aws_api_gateway_resource.v2_organizations_dev.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 # Root /heartbeat resource
@@ -104,11 +104,11 @@ resource "aws_api_gateway_resource" "organizations_dev" {
   path_part   = "organizations"
 }
 
-# /organizations/{orgid} resource
+# /organizations/{orgid+} resource
 resource "aws_api_gateway_resource" "organizations_orgid_dev" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_dev.id
   parent_id   = aws_api_gateway_resource.organizations_dev.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Purpose

This PR updates the API Gateway configuration to correctly handle organization IDs (orgIds) that include the "ror.org/" prefix.

## Approach

The change modifies the `path_part` for organization resources in both the `v2` and the root API paths. By changing `{orgid}` to `{orgid+}`, the API Gateway will now correctly capture and process orgIds that contain a slash, such as "ror.org/0xxxxxx", in addition to the existing "0xxxxx" format.

### Key Modifications

*   Updated `aws_api_gateway_resource.v2_organizations_orgid_dev` to use `path_part = "{orgid+}"`.
*   Updated `aws_api_gateway_resource.organizations_orgid_dev` to use `path_part = "{orgid+}"`.

### Important Technical Details

The `+` in `{orgid+}` signifies a greedy path variable in API Gateway. This means it will match one or more path segments, allowing it to capture the "ror.org/0xxxxxx" format.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.