### PR TITLE
feat: Update API Gateway staging config for dynamic org IDs

### DIFF
--- a/ror/services/api/api_gateway_staging_full.tf
+++ b/ror/services/api/api_gateway_staging_full.tf
@@ -77,11 +77,11 @@ resource "aws_api_gateway_resource" "v2_organizations_staging" {
   path_part   = "organizations"
 }
 
-# v2/organizations/{orgid} resource
+# v2/organizations/{orgid+} resource
 resource "aws_api_gateway_resource" "v2_organizations_orgid_staging" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_staging.id
   parent_id   = aws_api_gateway_resource.v2_organizations_staging.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 
@@ -106,11 +106,11 @@ resource "aws_api_gateway_resource" "organizations_staging" {
   path_part   = "organizations"
 }
 
-# /organizations/{orgid} resource
+# /organizations/{orgid+} resource
 resource "aws_api_gateway_resource" "organizations_orgid_staging" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway_staging.id
   parent_id   = aws_api_gateway_resource.organizations_staging.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Purpose

The purpose of this change is to update the API Gateway configuration for the staging environment to correctly handle organization IDs in resource paths.

## Approach

This PR modifies the `ror/services/api/api_gateway_staging_full.tf` file to change how organization IDs are defined in resource paths. Previously, they were defined as static placeholders, which would not allow for dynamic organization IDs to be passed in the URL. The change updates these to use the `+` suffix, which signifies a greedy path variable, allowing for variable organization IDs.

### Key Modifications

- Changed `path_part` from `"{orgid}"` to `"{orgid+}"` for the `v2_organizations_orgid_staging` resource.
- Changed `path_part` from `"{orgid}"` to `"{orgid+}"` for the `organizations_orgid_staging` resource.

### Important Technical Details

The `+` symbol in an API Gateway resource path part denotes a "greedy" path variable. This means it will match one or more path segments. This is crucial for correctly routing requests containing variable organization IDs that might include sub-paths.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.