### PR TITLE
feat: Allow multisearch query parameter in WAFv2

### DIFF
--- a/ror/vpc/wafv2.tf
+++ b/ror/vpc/wafv2.tf
@@ -436,7 +436,7 @@ resource "aws_wafv2_web_acl" "staging-v2" {
 
     custom_response_body {
         key           = "invalid_query_param_response"
-        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, validate\"]}"
+        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, multisearch, validate\"]}"
         content_type  = "APPLICATION_JSON"
     }
 

--- a/ror/vpc/wafv2.tf
+++ b/ror/vpc/wafv2.tf
@@ -60,7 +60,7 @@ resource "aws_wafv2_regex_pattern_set" "valid_query_params_v2" {
   scope = "REGIONAL"
   
   regular_expression {
-    regex_string = "^(query|page|affiliation|filter|format|all_status|query\\.advanced|query\\.name|query\\.names|single_search|validate)(=|$)"
+    regex_string = "^(query|page|affiliation|filter|format|all_status|query\\.advanced|query\\.name|query\\.names|single_search|multisearch|validate)(=|$)"
   }
   regular_expression {
     regex_string = "^$"
@@ -134,7 +134,7 @@ resource "aws_wafv2_web_acl" "dev-v2" {
 
     custom_response_body {
         key           = "invalid_query_param_response"
-        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, validate\"]}"
+        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, mutlisearch, validate\"]}"
         content_type  = "APPLICATION_JSON"
     }
 


### PR DESCRIPTION
## Purpose

This PR introduces a change to the WAFv2 configuration to allow the `multisearch` query parameter. This change affects both the development and staging environments.

## Approach

The WAFv2 configuration has been updated to include `multisearch` in both the regex pattern set for valid query parameters and the custom response body for invalid query parameters.

### Key Modifications

*   **`aws_wafv2_regex_pattern_set.valid_query_params_v2`**: Added `multisearch` to the `regex_string`.
*   **`aws_wafv2_web_acl.dev-v2`**: Added `multisearch` to the `content` of `custom_response_body` with key `invalid_query_param_response`.
*   **`aws_wafv2_web_acl.staging-v2`**: Added `multisearch` to the `content` of `custom_response_body` with key `invalid_query_param_response`.

### Important Technical Details

The `regex_string` update ensures that the `multisearch` parameter is now recognized as a valid query parameter by the WAF. The `custom_response_body` updates ensure that the error message displayed to users when an invalid query parameter is used is accurate and includes `multisearch` in the list of valid parameters.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.