### PR TITLE
fix: Revert WAF query parameter error body

### DIFF
--- a/ror/vpc/wafv2.tf
+++ b/ror/vpc/wafv2.tf
@@ -134,7 +134,7 @@ resource "aws_wafv2_web_acl" "dev-v2" {
 
     custom_response_body {
         key           = "invalid_query_param_response"
-        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, mutlisearch, validate\"]}"
+        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, validate\"]}"
         content_type  = "APPLICATION_JSON"
     }
 
@@ -436,7 +436,7 @@ resource "aws_wafv2_web_acl" "staging-v2" {
 
     custom_response_body {
         key           = "invalid_query_param_response"
-        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, multisearch, validate\"]}"
+        content       = "{\"errors\":[\"Query parameter is illegal. Valid parameters are: query, page, affiliation, filter, format, all_status, query.advanced, query.name, query.names, single_search, validate\"]}"
         content_type  = "APPLICATION_JSON"
     }
 


### PR DESCRIPTION
## Purpose

Revert the error body for parameters in the WAF to temporarily address an issue with query parameter validation.

## Approach

This PR reverts the `content` field within the `custom_response_body` for the `invalid_query_param_response` key in the `aws_wafv2_web_acl` resource for both `dev-v2` and `staging-v2`. This change temporarily removes "multisearch" from the list of valid query parameters in the error response.

### Key Modifications

*   Reverted the `content` value for `invalid_query_param_response` in `ror/vpc/wafv2.tf` for the `dev-v2` WAF ACL.
*   Reverted the `content` value for `invalid_query_param_response` in `ror/vpc/wafv2.tf` for the `staging-v2` WAF ACL.

### Important Technical Details

The change specifically modifies the JSON string returned in the error response when an invalid query parameter is detected by the WAF. The parameter "multisearch" was mistakenly included in the previous commit and is now removed to align with the intended validation logic.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.