### PR TITLE
feat: Set `create_before_destroy` to true for `aws_api_gateway_deployment`

### DIFF
--- a/ror/services/api/api_gateway_prod_full.tf
+++ b/ror/services/api/api_gateway_prod_full.tf
@@ -1600,9 +1600,10 @@ resource "aws_api_gateway_deployment" "api_gateway" {
   ]
 
   lifecycle {
-    # Phase 1 PR1: in-place deployment replace before proxy route removal (PR2).
-    # Restore create_before_destroy = true after Phase 1 completes.
-    create_before_destroy = false
+    # PR1 keeps create_before_destroy true so stage moves before old deployment is
+    # deleted (false causes "Active stages pointing to this deployment" on 0.12).
+    # Set false in PR2 (proxy removal); re-enable true after Phase 1 completes.
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Purpose

This PR modifies the `aws_api_gateway_deployment` resource's lifecycle to ensure a smooth deployment process, specifically addressing the `create_before_destroy` setting.

## Approach

The `create_before_destroy` setting for the `aws_api_gateway_deployment` resource is adjusted to `true`. This change is crucial for allowing the API Gateway stage to be updated with the new deployment before the old deployment is removed. This prevents errors related to active stages pointing to a deployment that is being destroyed.

### Key Modifications

*   Changed `create_before_destroy` from `false` to `true` in the `aws_api_gateway_deployment` resource.

### Important Technical Details

The `create_before_destroy = true` setting is essential for API Gateway deployments, particularly when dealing with in-place deployments and the subsequent removal of proxy routes. Setting it to `false` in earlier versions of Terraform could lead to errors if stages were actively using the deployment being destroyed. This change ensures that the new deployment is created and active before the old one is purged, maintaining service availability. This is a temporary setting requested for Phase 1 of the API Gateway deployment process and will be reverted in a subsequent PR.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.