### PR TITLE
fix(terraform): enable create_before_destroy for aws_api_gateway_deployment

### DIFF
--- a/ror/services/api/api_gateway_prod_full.tf
+++ b/ror/services/api/api_gateway_prod_full.tf
@@ -1312,9 +1312,10 @@ resource "aws_api_gateway_deployment" "api_gateway" {
   ]
 
   lifecycle {
-    # Phase 1 PR2: avoid deployment/stage/proxy destroy cycle on 0.12.
-    # Re-enable create_before_destroy = true in PR3 after prod is stable.
-    create_before_destroy = false
+    # Keep true on 0.12: false deletes the old deployment before the prod stage moves
+    # ("Active stages pointing to this deployment"). PR1 prep + two-PR split avoids
+    # the earlier destroy cycle without needing false here.
+    create_before_destroy = true
   }
 }
 


### PR DESCRIPTION
## Purpose

This PR addresses an issue with the `aws_api_gateway_deployment` resource in Terraform configuration. Specifically, it modifies the `create_before_destroy` lifecycle setting to ensure stability during deployments.

## Approach

The `create_before_destroy` setting for the `aws_api_gateway_deployment` resource has been changed from `false` to `true`. This change is intended to prevent an unintended destroy cycle of the deployment and stage during upgrades.

### Key Modifications

*   Changed `create_before_destroy` from `false` to `true` in the `aws_api_gateway_deployment` resource.

### Important Technical Details

The previous setting of `create_before_destroy = false` could lead to the deletion of the old deployment before the production stage could be updated to point to the new deployment. This could have caused brief service interruptions. Setting it to `true` ensures that a new deployment is created before the old one is destroyed, thus maintaining service availability. This change aligns with best practices for managing API Gateway deployments in Terraform, especially when dealing with version upgrades or significant configuration changes.

## Types of changes

*   [ ] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.