### PR TITLE
Feat: Update API Gateway to use greedy path matching for organization IDs

### DIFF
--- a/ror/services/api/api_gateway_prod_full.tf
+++ b/ror/services/api/api_gateway_prod_full.tf
@@ -73,11 +73,11 @@ resource "aws_api_gateway_resource" "v2_organizations" {
   path_part   = "organizations"
 }
 
-# v2/organizations/{orgid} resource
+# v2/organizations/{orgid+} resource (greedy path; matches staging)
 resource "aws_api_gateway_resource" "v2_organizations_orgid" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   parent_id   = aws_api_gateway_resource.v2_organizations.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 # Root /heartbeat resource for versionless requests  
@@ -101,11 +101,11 @@ resource "aws_api_gateway_resource" "organizations" {
   path_part   = "organizations"
 }
 
-# /organizations/{orgid} resource
+# /organizations/{orgid+} resource (greedy path; matches staging)
 resource "aws_api_gateway_resource" "organizations_orgid" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   parent_id   = aws_api_gateway_resource.organizations.id
-  path_part   = "{orgid}"
+  path_part   = "{orgid+}"
 }
 
 # =============================================================================
@@ -1393,11 +1393,11 @@ resource "aws_api_gateway_method_settings" "organizations_cache_prod" {
   }
 }
 
-# Disable caching for /organizations/{orgid} endpoint
+# Disable caching for /organizations/{orgid+} endpoint
 resource "aws_api_gateway_method_settings" "organizations_orgid_no_cache_prod" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   stage_name  = aws_api_gateway_stage.api_gateway_prod.stage_name
-  method_path = "organizations/{orgid}/GET"
+  method_path = "organizations/{orgid+}/GET"
 
   settings {
     caching_enabled        = false
@@ -1429,11 +1429,11 @@ resource "aws_api_gateway_method_settings" "v2_organizations_cache_prod" {
   }
 }
 
-# Disable caching for v2/organizations/{orgid} endpoint
+# Disable caching for v2/organizations/{orgid+} endpoint
 resource "aws_api_gateway_method_settings" "v2_organizations_orgid_no_cache_prod" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   stage_name  = aws_api_gateway_stage.api_gateway_prod.stage_name
-  method_path = "v2/organizations/{orgid}/GET"
+  method_path = "v2/organizations/{orgid+}/GET"
 
   settings {
     caching_enabled        = false


### PR DESCRIPTION
## Purpose

This PR updates the API Gateway configuration to use greedy path matching for organization IDs in both the v1 and v2 endpoints. This change ensures that the API Gateway correctly handles requests with varying levels of path depth for organization IDs, aligning it with the behavior in the staging environment.

## Approach

The primary modification involves changing the `path_part` for the organization ID resource from `{orgid}` to `{orgid+}` within the `ror/services/api/api_gateway_prod_full.tf` file. This utilizes the greedy path variable feature in API Gateway, which matches one or more characters for the specified path segment. Additionally, the `method_path` in the `aws_api_gateway_method_settings` resources has been updated to reflect this change, ensuring that caching configurations are correctly applied to the newly defined greedy path.

### Key Modifications

*   Changed `path_part` from `{orgid}` to `{orgid+}` for `aws_api_gateway_resource.v2_organizations_orgid`.
*   Changed `path_part` from `{orgid}` to `{orgid+}` for `aws_api_gateway_resource.organizations_orgid`.
*   Updated `method_path` in `aws_api_gateway_method_settings.organizations_orgid_no_cache_prod` to use `{orgid+}`.
*   Updated `method_path` in `aws_api_gateway_method_settings.v2_organizations_orgid_no_cache_prod` to use `{orgid+}`.

### Important Technical Details

The use of `{orgid+}` signifies a greedy path variable. This means that API Gateway will match any path segment following `/organizations/` or `/v2/organizations/` as the `orgid`, including paths with multiple segments (e.g., `/organizations/a/b/c`). This change is intended to bring the production environment's API Gateway route matching in consistency with the staging environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.