### PR TITLE
feat: Add multisearch query parameter to organizations API

### DIFF
--- a/ror/services/api/api_gateway_prod_full.tf
+++ b/ror/services/api/api_gateway_prod_full.tf
@@ -183,6 +183,7 @@ resource "aws_api_gateway_method" "organizations_any" {
     "method.request.querystring.query.names" = false
     "method.request.querystring.page_size" = false
     "method.request.querystring.single_search" = false
+    "method.request.querystring.multisearch" = false
   }
 }
 
@@ -217,6 +218,7 @@ resource "aws_api_gateway_method" "v2_organizations_any" {
     "method.request.querystring.query.names" = false
     "method.request.querystring.page_size" = false
     "method.request.querystring.single_search" = false
+    "method.request.querystring.multisearch" = false
   }
 }
 
@@ -511,6 +513,7 @@ resource "aws_api_gateway_integration" "organizations_any" {
     "integration.request.querystring.query.names" = "method.request.querystring.query.names"
     "integration.request.querystring.page_size" = "method.request.querystring.page_size"
     "integration.request.querystring.single_search" = "method.request.querystring.single_search"
+    "integration.request.querystring.multisearch" = "method.request.querystring.multisearch"
   }
 
   # Caching configuration - cache by query parameters
@@ -525,7 +528,8 @@ resource "aws_api_gateway_integration" "organizations_any" {
     "method.request.querystring.query.name",
     "method.request.querystring.query.names",
     "method.request.querystring.page_size",
-    "method.request.querystring.single_search"
+    "method.request.querystring.single_search",
+    "method.request.querystring.multisearch"
   ]
   cache_namespace = "organizations"
 }
@@ -573,6 +577,7 @@ resource "aws_api_gateway_integration" "v2_organizations_any" {
     "integration.request.querystring.query.names" = "method.request.querystring.query.names"
     "integration.request.querystring.page_size" = "method.request.querystring.page_size"
     "integration.request.querystring.single_search" = "method.request.querystring.single_search"
+    "integration.request.querystring.multisearch" = "method.request.querystring.multisearch"
   }
 
   # Caching configuration - cache by query parameters
@@ -587,7 +592,8 @@ resource "aws_api_gateway_integration" "v2_organizations_any" {
     "method.request.querystring.query.name",
     "method.request.querystring.query.names",
     "method.request.querystring.page_size",
-    "method.request.querystring.single_search"
+    "method.request.querystring.single_search",
+    "method.request.querystring.multisearch"
   ]
   cache_namespace = "v2-organizations"
 }


### PR DESCRIPTION
## Purpose

This PR updates the API Gateway configuration to include the `multisearch` query string parameter for both the `organizations_any` and `v2_organizations_any` resources.

## Approach

The changes involve modifying the AWS API Gateway method and integration resources to recognize and pass the `multisearch` query parameter.

### Key Modifications

*   Added `"method.request.querystring.multisearch" = false` to the `aws_api_gateway_method.organizations_any` resource.
*   Added `"method.request.querystring.multisearch" = false` to the `aws_api_gateway_method.v2_organizations_any` resource.
*   Mapped `"integration.request.querystring.multisearch" = "method.request.querystring.multisearch"` in the `aws_api_gateway_integration.organizations_any` resource.
*   Included `"method.request.querystring.multisearch"` in the `cache_key_parameters` for `aws_api_gateway_integration.organizations_any`.
*   Mapped `"integration.request.querystring.multisearch" = "method.request.querystring.multisearch"` in the `aws_api_gateway_integration.v2_organizations_any` resource.
*   Included `"method.request.querystring.multisearch"` in the `cache_key_parameters` for `aws_api_gateway_integration.v2_organizations_any`.

### Important Technical Details

The `multisearch` query string parameter is now explicitly handled by API Gateway, allowing it to be passed through to the backend integration and used in cache key generation. This change ensures that requests with this parameter are correctly processed and cached.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.