### PR TITLE
Allow `bulkupdate` requests through the ROR staging ALB listener

### DIFF
--- a/ror/vpc/alb-staging.tf
+++ b/ror/vpc/alb-staging.tf
@@ -100,7 +100,24 @@ resource "aws_lb_listener_rule" "allow_indexdatadump_staging" {
   }
 }
 
-# Rule 4: Block API paths without proper authentication (return 403)
+# Rule 4: Allow traffic with "bulkupdate" in the path
+resource "aws_lb_listener_rule" "allow_bulkupdate_staging" {
+  listener_arn = aws_lb_listener.alb-staging.arn
+  priority = 40
+
+  action {
+    type             = "forward"
+    target_group_arn = data.aws_lb_target_group.api-staging.id
+  }
+
+  condition {
+    path_pattern {
+      values = ["*bulkupdate*"]
+    }
+  }
+}
+
+# Rule 5: Block API paths without proper authentication (return 403)
 resource "aws_lb_listener_rule" "block_api_traffic_staging" {
   listener_arn = aws_lb_listener.alb-staging.arn
   priority = 90


### PR DESCRIPTION
## Purpose
Allow requests containing `bulkupdate` in the path to reach the ROR staging API by adding an explicit allow rule on the staging ALB listener.

## Approach
Add a new ALB listener rule with a higher priority (lower number) than the existing API-blocking rule so that bulk-update traffic is forwarded before the 403 block rule is evaluated.

### Key Modifications
- Added `aws_lb_listener_rule.allow_bulkupdate_staging` in `ror/vpc/alb-staging.tf`.
  - Forwards matching traffic to the `api-staging` target group.
  - Uses path pattern `*bulkupdate*` to match any request containing `bulkupdate` in the URL.
  - Assigned priority `40`.
- Renumbered the existing API block rule comment from `Rule 4` to `Rule 5` (priority remains `90`).

### Important Technical Details
- ALB listener rules are evaluated in priority order, so the new allow rule at priority `40` must run before the block rule at priority `90`.
- This change applies only to the staging environment (`alb-staging.tf`); production ALB rules are not affected.
- No authentication logic is changed; the existing block rule continues to return `403` for unmatched API paths.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.